### PR TITLE
Using `.buildVoid()` for endpoints having no outputs

### DIFF
--- a/backend/src/endpoints/disconnect-telegram.ts
+++ b/backend/src/endpoints/disconnect-telegram.ts
@@ -1,12 +1,9 @@
-import { z } from "zod";
 import { authorizedUserFactory } from "../factories.js";
 
-export const disconnectTelegramEndpoint = authorizedUserFactory.build({
+export const disconnectTelegramEndpoint = authorizedUserFactory.buildVoid({
   method: "delete",
-  output: z.object({}),
   handler: async ({ options: { user } }) => {
     user.telegramChatId = undefined;
     await user.save();
-    return {};
   },
 });

--- a/backend/src/endpoints/remove-registration.ts
+++ b/backend/src/endpoints/remove-registration.ts
@@ -1,16 +1,13 @@
-import { z } from "zod";
 import { Users } from "../db.js";
 import { authorizedUserFactory } from "../factories.js";
 
-export const removeRegistrationEndpoint = authorizedUserFactory.build({
+export const removeRegistrationEndpoint = authorizedUserFactory.buildVoid({
   method: "delete",
-  output: z.object({}),
   handler: async ({
     options: {
       user: { _id },
     },
   }) => {
     await Users.deleteOne({ _id }).exec();
-    return {};
   },
 });

--- a/backend/src/endpoints/toggle-public-status.ts
+++ b/backend/src/endpoints/toggle-public-status.ts
@@ -1,15 +1,13 @@
 import { z } from "zod";
 import { authorizedUserFactory } from "../factories.js";
 
-export const togglePublicStatusEndpoint = authorizedUserFactory.build({
+export const togglePublicStatusEndpoint = authorizedUserFactory.buildVoid({
   method: "patch",
   input: z.object({
     isPublic: z.boolean(),
   }),
-  output: z.object({}),
   handler: async ({ input: { isPublic }, options: { user } }) => {
     user.isPublic = isPublic;
     await user.save();
-    return {};
   },
 });


### PR DESCRIPTION
feature of v21.4